### PR TITLE
Remove --add-std flag

### DIFF
--- a/solc_helper
+++ b/solc_helper
@@ -9,7 +9,7 @@ end
 
 
 def compile_solidity(file)
-  json_string = `solc --add-std --optimize --combined-json abi,bin,userdoc,devdoc #{file}`
+  json_string = `solc --optimize --combined-json abi,bin,userdoc,devdoc #{file}`
   json_string = json_string.gsub("\\n","")
   begin
     json_object = JSON.parse(json_string)


### PR DESCRIPTION
The `--add-std` flag appears to have been deprecated.